### PR TITLE
fix: Update image tag to version 2.6.0

### DIFF
--- a/helm/uat/top/rtp-activator/values.yaml
+++ b/helm/uat/top/rtp-activator/values.yaml
@@ -3,7 +3,7 @@ microservice-chart:
 
   image:
     repository: ghcr.io/pagopa/rtp-activator
-    tag: "1.58.2-RC"
+    tag: "2.6.0"
     pullPolicy: Always
 
   ingress:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR updates the Helm values for the `rtp-activator` microservice to use the latest image version.

#### List of Changes

<!--- Describe your changes in detail -->

- Updated Docker image tag from `1.58.2-RC` to `2.6.0` in `helm/uat/top/rtp-activator/values.yaml`.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The goal of this change is to align the UAT deployment of `rtp-activator` with the most recent stable version (`2.6.0`), in order to run validation and regression tests against the latest build.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
