### PR TITLE
feat: [SRTP-1584] add feature flag for GPD message processing enabling

### DIFF
--- a/helm/dev/top/rtp-consumer/values.yaml
+++ b/helm/dev/top/rtp-consumer/values.yaml
@@ -38,6 +38,7 @@ microservice-chart:
     GPD_EVENTHUB_NAME: "pagopa-d-itn-gps-rtp-integration-evh"
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
+    GPD_MESSAGE_PROCESSING_ENABLED: "true"
 
   keyvault:
     name: "cstar-d-itn-srtp-kv"

--- a/helm/prod/top/rtp-consumer/values.yaml
+++ b/helm/prod/top/rtp-consumer/values.yaml
@@ -36,6 +36,7 @@ microservice-chart:
     GPD_EVENTHUB_NAME: "pagopa-p-itn-gps-rtp-integration-evh"
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
+    GPD_MESSAGE_PROCESSING_ENABLED: "false"
 
   keyvault:
     name: "cstar-p-itn-srtp-kv"

--- a/helm/uat/top/rtp-consumer/values.yaml
+++ b/helm/uat/top/rtp-consumer/values.yaml
@@ -36,6 +36,7 @@ microservice-chart:
     GPD_EVENTHUB_NAME: "pagopa-u-itn-gps-rtp-integration-evh"
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
+    GPD_MESSAGE_PROCESSING_ENABLED: "true"
 
   keyvault:
     name: "cstar-u-itn-srtp-kv"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
#### List of Changes
This PR adds the `GPD_MESSAGE_PROCESSING_ENABLED` environment variable to the Helm values files for all three environments in `rtp-consumer` service:

- **dev**: `GPD_MESSAGE_PROCESSING_ENABLED: "true"`
- **uat**: `GPD_MESSAGE_PROCESSING_ENABLED: "true"`
- **prod**: `GPD_MESSAGE_PROCESSING_ENABLED: "false"`

#### Motivation and Context
This change introduces a feature flag to control whether _GPD_ message processing is active in the `rtp-consumer` microservice. 
The flag allows the team to enable the feature in lower environments (DEV and UAT) for testing and validation, while keeping it safely disabled in production until the feature is fully verified and a deliberate rollout decision is made.

This pattern avoids the need for separate code deployments to toggle the behaviour, reducing risk when promoting to production.

#### How Has This Been Tested?

Manually run `srtp-deploy-aks.deploy` in DEV and the env var show up valued as expected.

#### Screenshots (if appropriate):

N/A

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.