### PR TITLE
feat: [SRTP-1613] Add new repo rtp-payees

### DIFF
--- a/.devops/deploy-argocd-apps.yml
+++ b/.devops/deploy-argocd-apps.yml
@@ -33,6 +33,7 @@ parameters:
     - rtp-activator
     - rtp-sender
     - rtp-consumer
+    - rtp-payees
 
 - name: APPS_MID
   displayName: Mid ArgoCD Apps. Set to [] to skip deployment.

--- a/helm/_global/rtp-payees.yaml
+++ b/helm/_global/rtp-payees.yaml
@@ -1,0 +1,100 @@
+microservice-chart:
+  namespace: "srtp"
+
+  deployment:
+    create: true
+    topologySpreadConstraints:
+      create: true
+      useDefaultConfiguration: true
+
+  livenessProbe:
+    httpGet:
+      path: /actuator/health/liveness
+      port: 8080
+    initialDelaySeconds: 60
+    failureThreshold: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+
+  readinessProbe:
+    httpGet:
+      path: /actuator/health/readiness
+      port: 8080
+    initialDelaySeconds: 10
+    failureThreshold: 6
+    periodSeconds: 10
+    timeoutSeconds: 5
+
+
+  service:
+    create: true
+    type: ClusterIP
+    ports:
+      - 8080
+
+  ingress:
+    create: true
+    path: /rtppayees(/|$)(.*)
+    rewriteTarget: /$2
+    servicePort: 8080
+    # proxyBodySize: 2m
+    annotations: {
+      nginx.ingress.kubernetes.io/satisfy: "any"
+    }
+
+  podAnnotations: {}
+
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+
+  tmpVolumeMount:
+    create: true
+    mounts:
+      - name: tmp
+        mountPath: /tmp
+      - name: logs
+        mountPath: /app/logs
+
+  envConfig:
+    TZ: "Europe/Rome"
+    OTEL_SERVICE_NAME: "rtp-payees"
+    OTEL_TRACES_SAMPLER: "always_on"
+    LOG_LEVEL_ROOT: "INFO"
+    LOG_LEVEL_PAGOPA: "INFO"
+    LOG_LEVEL_SPRING_INTEGRATION: "WARN"
+    LOG_LEVEL_SPRING_SECURITY: "INFO"
+    LOG_LEVEL_SPRING_WS: "WARN"
+    LOG_LEVEL_SPRING_CLOUD: "WARN"
+    LOG_LEVEL_SPRING_DATA: "WARN"
+    LOG_LEVEL_SPRING_BOOT: "WARN"
+    LOG_LEVEL_SPRING_BOOT_AVAILABILITY: "WARN"
+    LOG_LEVEL_IO_SWAGGER: "WARN"
+    LOG_LEVEL_JAVAX_PERSISTENCE: "WARN"
+    LOG_LEVEL_ORG_HIBERNATE: "WARN"
+    LOG_LEVEL_MONGODB_DRIVER: "WARN"
+
+  envSecret:
+    APPLICATIONINSIGHTS_CONNECTION_STRING: "appinsights-connection-string"
+
+  tolerations:
+    - key: "srtpOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "domain"
+                operator: "In"
+                values:
+                  - "srtp"

--- a/helm/dev/top/rtp-payees/Chart.lock
+++ b/helm/dev/top/rtp-payees/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: microservice-chart
+  repository: https://pagopa.github.io/aks-microservice-chart-blueprint
+  version: 8.1.1
+digest: sha256:211d299287a6c16548fd6e5c8ab7c13bd6265cfac30927a675fe183625f21a5e
+generated: "2025-10-30T16:26:50.744867+01:00"

--- a/helm/dev/top/rtp-payees/Chart.yaml
+++ b/helm/dev/top/rtp-payees/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: rtp-payees
+description: SRTP PAYEES
+type: application
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: microservice-chart
+    version: 8.1.1
+    repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/dev/top/rtp-payees/values.yaml
+++ b/helm/dev/top/rtp-payees/values.yaml
@@ -1,0 +1,44 @@
+microservice-chart:
+  namespace: "srtp"
+
+  image:
+    repository: ghcr.io/pagopa/rtp-payees
+    tag: snapshot-main
+    pullPolicy: Always
+
+
+  ingress:
+    host: "srtp.itn.internal.dev.cstar.pagopa.it"
+
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "100Mi"
+      cpu: "100m"
+
+  autoscaling:
+    enable: false
+  #    minReplica: 1
+  #    maxReplica: 3
+  #    pollingInterval: 30 # seconds
+  #    cooldownPeriod: 300 # seconds
+  #    triggers:
+  #      - type: cpu
+  #        metadata:
+  #          type: Utilization
+  #          value: "60"
+
+  envConfig:
+    BASE_URL: "https://api-rtp.dev.cstar.pagopa.it/rtp/payees/"
+
+  keyvault:
+    name: "cstar-d-itn-srtp-kv"
+    tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
+
+  # nodeSelector: {}
+
+  # tolerations: []
+
+  # affinity: {}

--- a/helm/prod/top/rtp-payees/Chart.lock
+++ b/helm/prod/top/rtp-payees/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: microservice-chart
+  repository: https://pagopa.github.io/aks-microservice-chart-blueprint
+  version: 8.1.1
+digest: sha256:211d299287a6c16548fd6e5c8ab7c13bd6265cfac30927a675fe183625f21a5e
+generated: "2025-10-30T16:27:03.858957+01:00"

--- a/helm/prod/top/rtp-payees/Chart.yaml
+++ b/helm/prod/top/rtp-payees/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: rtp-payees
+description: SRTP PAYEES
+type: application
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: microservice-chart
+    version: 8.1.1
+    repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/prod/top/rtp-payees/values.yaml
+++ b/helm/prod/top/rtp-payees/values.yaml
@@ -1,0 +1,37 @@
+microservice-chart:
+  namespace: "srtp"
+
+  image:
+    repository: ghcr.io/pagopa/rtp-payees
+    tag: v1.11.0
+    pullPolicy: Always
+
+  ingress:
+    host: "srtp.itn.internal.cstar.pagopa.it"
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+  autoscaling:
+    enable: false
+  #    minReplica: 1
+  #    maxReplica: 3
+  #    pollingInterval: 30 # seconds
+  #    cooldownPeriod: 300 # seconds
+  #    triggers:
+  #      - type: cpu
+  #        metadata:
+  #          type: Utilization
+  #          value: "60"
+
+  envConfig:
+    BASE_URL: "https://api-rtp.cstar.pagopa.it/rtp/payees/"
+
+  keyvault:
+    name: "cstar-p-itn-srtp-kv"
+    tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"

--- a/helm/uat/top/rtp-payees/Chart.lock
+++ b/helm/uat/top/rtp-payees/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: microservice-chart
+  repository: https://pagopa.github.io/aks-microservice-chart-blueprint
+  version: 8.1.1
+digest: sha256:211d299287a6c16548fd6e5c8ab7c13bd6265cfac30927a675fe183625f21a5e
+generated: "2025-10-30T16:27:11.874326+01:00"

--- a/helm/uat/top/rtp-payees/Chart.yaml
+++ b/helm/uat/top/rtp-payees/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: rtp-payees
+description: SRTP PAYEES
+type: application
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: microservice-chart
+    version: 8.1.1
+    repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/uat/top/rtp-payees/values.yaml
+++ b/helm/uat/top/rtp-payees/values.yaml
@@ -1,0 +1,37 @@
+microservice-chart:
+  namespace: "srtp"
+
+  image:
+    repository: ghcr.io/pagopa/rtp-payees
+    tag: snapshot-main
+    pullPolicy: Always
+
+  ingress:
+    host: "srtp.itn.internal.uat.cstar.pagopa.it"
+
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "250m"
+      memory: "512Mi"
+
+  autoscaling:
+    enable: false
+#    minReplica: 1
+#    maxReplica: 3
+#    pollingInterval: 30
+#    cooldownPeriod: 300
+#    triggers:
+#      - type: cpu
+#        metadata:
+#          type: Utilization
+#          value: "60"
+
+  envConfig:
+    BASE_URL: "https://api-rtp.uat.cstar.pagopa.it/rtp/payees/"
+
+  keyvault:
+    name: "cstar-u-itn-srtp-kv"
+    tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added `rtp-payees` microservice to `APPS_TOP` parameter in `.devops/deploy-argocd-apps.yml` to enable its deployment via ArgoCD.
- Created global Helm configuration for `rtp-payees` in `helm/_global/rtp-payees.yaml`.
- Created environment-specific Helm values and charts for `rtp-payees` in `helm/dev`, `helm/uat`, and `helm/prod`.

#### Motivation and Context

This PR introduces the `rtp-payees` microservice into the SRTP (Real-Time Payment) ecosystem across all target environments (DEV, UAT, PROD). It also performs a small cleanup by removing an obsolete configuration flag from the `rtp-consumer` service.

#### How Has This Been Tested?

The changes involve infrastructure and configuration updates. Verification should include:
- Successful ArgoCD synchronization of the new `rtp-payees` application.
- Health checks of the `rtp-payees` pods in the respective environments.
- Verification that `rtp-consumer` continues to operate correctly after the configuration cleanup.

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
