### PR TITLE
feat: [SRTP-1680] add ADX configuration to rtp-sender helm values

### DIFF
--- a/helm/dev/top/rtp-sender/values.yaml
+++ b/helm/dev/top/rtp-sender/values.yaml
@@ -44,6 +44,8 @@ microservice-chart:
     MIL_AUTH_TOKEN_URL: "https://api-mcshared.dev.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token"
     FEATURE_TOGGLE_ENABLE_LAST_PROCESSED_TIMESTAMP: "false"
     IDEMPOTENCY_TTL: "PT5M"
+    ADX_CLUSTER_URL: "https://cstar-d-itn-platform.italynorth.kusto.windows.net"
+    ADX_DATABASE_NAME: "srtp"
 
   keyvault:
     name: "cstar-d-itn-srtp-kv"

--- a/helm/prod/top/rtp-sender/values.yaml
+++ b/helm/prod/top/rtp-sender/values.yaml
@@ -44,6 +44,8 @@ microservice-chart:
     MIL_AUTH_TOKEN_URL: "https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token"
     FEATURE_TOGGLE_ENABLE_LAST_PROCESSED_TIMESTAMP: "false"
     IDEMPOTENCY_TTL: "P30D"
+    ADX_CLUSTER_URL: "https://cstar-itn-platform.italynorth.kusto.windows.net"
+    ADX_DATABASE_NAME: "srtp"
 
   keyvault:
     name: "cstar-p-itn-srtp-kv"

--- a/helm/prod/top/rtp-sender/values.yaml
+++ b/helm/prod/top/rtp-sender/values.yaml
@@ -44,7 +44,7 @@ microservice-chart:
     MIL_AUTH_TOKEN_URL: "https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token"
     FEATURE_TOGGLE_ENABLE_LAST_PROCESSED_TIMESTAMP: "false"
     IDEMPOTENCY_TTL: "P30D"
-    ADX_CLUSTER_URL: "https://cstar-itn-platform.italynorth.kusto.windows.net"
+    ADX_CLUSTER_URL: "https://cstar-p-itn-platform.italynorth.kusto.windows.net"
     ADX_DATABASE_NAME: "srtp"
 
   keyvault:

--- a/helm/uat/top/rtp-sender/values.yaml
+++ b/helm/uat/top/rtp-sender/values.yaml
@@ -44,6 +44,8 @@ microservice-chart:
     MIL_AUTH_TOKEN_URL: "https://api-mcshared.uat.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token"
     FEATURE_TOGGLE_ENABLE_LAST_PROCESSED_TIMESTAMP: "false"
     IDEMPOTENCY_TTL: "P7D"
+    ADX_CLUSTER_URL: "https://cstar-u-itn-platform.italynorth.kusto.windows.net"
+    ADX_DATABASE_NAME: "srtp"
 
   keyvault:
     name: "cstar-u-itn-srtp-kv"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Added `ADX_CLUSTER_URL` and `ADX_DATABASE_NAME` environment variables to `rtp-sender` Helm values across all environments (DEV, UAT, PROD)
* Configured the microservice to connect to the correct Azure Data Explorer (Kusto) cluster endpoint per environment

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The `rtp-sender` microservice requires access to Azure Data Explorer (ADX) in order to query RTP data.

Previously, the ADX connection parameters were not defined in the Helm configuration, causing the service to be unable to properly connect to the Kusto cluster.

This change introduces the required configuration:

* `ADX_CLUSTER_URL`
* `ADX_DATABASE_NAME`

and aligns all environments (DEV, UAT, PROD) with consistent and explicit ADX connectivity settings.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
