### PR TITLE
feat: [SRTP-1725] Backoffice BASE URL for OPT OUT

### DIFF
--- a/helm/dev/top/rtp-payees/values.yaml
+++ b/helm/dev/top/rtp-payees/values.yaml
@@ -32,6 +32,7 @@ microservice-chart:
 
   envConfig:
     BASE_URL: "https://api-rtp.dev.cstar.pagopa.it/rtp/payees/"
+    BACKOFFICE_BASE_URL: "https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1/institutions/services/RTP/consents"
 
   keyvault:
     name: "cstar-d-itn-srtp-kv"

--- a/helm/dev/top/rtp-payees/values.yaml
+++ b/helm/dev/top/rtp-payees/values.yaml
@@ -32,7 +32,7 @@ microservice-chart:
 
   envConfig:
     BASE_URL: "https://api-rtp.dev.cstar.pagopa.it/rtp/payees/"
-    BACKOFFICE_BASE_URL: "https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1/institutions/services/RTP/consents"
+    BACKOFFICE_BASE_URL: "https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1"
 
   keyvault:
     name: "cstar-d-itn-srtp-kv"

--- a/helm/prod/top/rtp-payees/values.yaml
+++ b/helm/prod/top/rtp-payees/values.yaml
@@ -31,7 +31,7 @@ microservice-chart:
 
   envConfig:
     BASE_URL: "https://api-rtp.cstar.pagopa.it/rtp/payees/"
-    BACKOFFICE_BASE_URL: "https://api.platform.pagopa.it/backoffice/pagopa/services/v1/institutions/services/RTP/consents"
+    BACKOFFICE_BASE_URL: "https://api.platform.pagopa.it/backoffice/pagopa/services/v1"
 
   keyvault:
     name: "cstar-p-itn-srtp-kv"

--- a/helm/prod/top/rtp-payees/values.yaml
+++ b/helm/prod/top/rtp-payees/values.yaml
@@ -31,6 +31,7 @@ microservice-chart:
 
   envConfig:
     BASE_URL: "https://api-rtp.cstar.pagopa.it/rtp/payees/"
+    BACKOFFICE_BASE_URL: "https://api.platform.pagopa.it/backoffice/pagopa/services/v1/institutions/services/RTP/consents"
 
   keyvault:
     name: "cstar-p-itn-srtp-kv"

--- a/helm/uat/top/rtp-payees/values.yaml
+++ b/helm/uat/top/rtp-payees/values.yaml
@@ -31,6 +31,7 @@ microservice-chart:
 
   envConfig:
     BASE_URL: "https://api-rtp.uat.cstar.pagopa.it/rtp/payees/"
+    BACKOFFICE_BASE_URL: "https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1/institutions/services/RTP/consents"
 
   keyvault:
     name: "cstar-u-itn-srtp-kv"

--- a/helm/uat/top/rtp-payees/values.yaml
+++ b/helm/uat/top/rtp-payees/values.yaml
@@ -31,7 +31,7 @@ microservice-chart:
 
   envConfig:
     BASE_URL: "https://api-rtp.uat.cstar.pagopa.it/rtp/payees/"
-    BACKOFFICE_BASE_URL: "https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1/institutions/services/RTP/consents"
+    BACKOFFICE_BASE_URL: "https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1"
 
   keyvault:
     name: "cstar-u-itn-srtp-kv"


### PR DESCRIPTION
#### List of Changes

Added `BACKOFFICE_BASE_URL` environment variable to `rtp-payees` Helm values for all environments:
- **dev**: `https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1`
- **uat**: `https://api.uat.platform.pagopa.it/backoffice/pagopa/services/v1`
- **prod**: `https://api.platform.pagopa.it/backoffice/pagopa/services/v1`

#### Motivation and Context

The `rtp-payees` service requires a backoffice base URL to communicate with the PagoPA backoffice API. This change introduces the missing `BACKOFFICE_BASE_URL` config entry across all deployment environments so the service can resolve the correct endpoint at runtime.

#### How Has This Been Tested?

Configuration change only — no logic was modified. Values were verified against the existing environment URL patterns used in the same files.

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
