### PR TITLE
feat: [SRTP-1764] Add postman tests for payees

### DIFF
--- a/helm/uat/top/rtp-payees/values.yaml
+++ b/helm/uat/top/rtp-payees/values.yaml
@@ -36,3 +36,10 @@ microservice-chart:
   keyvault:
     name: "cstar-u-itn-srtp-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
+
+postman-test:
+  run: true
+  repoName: rtp-payees
+  dir: postman
+  collectionName: "rtp-payees-E2E.postman_collection.json"
+  envVariablesFile: "rtp_uat.postman_environment.json" #inside azdo secure files


### PR DESCRIPTION
#### List of Changes

- Added `postman-test` configuration block to [helm/uat/top/rtp-payees/values.yaml](helm/uat/top/rtp-payees/values.yaml) for the `rtp-payees` service in UAT environment.
- The configuration enables automated Postman E2E test execution, pointing to the `rtp-payees-E2E.postman_collection.json` collection and the `rtp_uat.postman_environment.json` environment variables file (stored as an Azure DevOps secure file).

#### Motivation and Context

The `rtp-payees` microservice was missing Postman-based E2E test coverage in the UAT pipeline. This change enables automated integration tests to run after deployment, ensuring the payees service behaves correctly end-to-end in the UAT environment. The test collection and environment file are already available in the service repository and in Azure DevOps secure files respectively.

#### How Has This Been Tested?

Configuration follows the same pattern already in use by other microservices in this repository. The Postman collection (`rtp-payees-E2E.postman_collection.json`) and environment file (`rtp_uat.postman_environment.json`) are pre-existing artifacts. The change can be validated by triggering a UAT deployment of `rtp-payees` and verifying the postman-test step runs and passes in the pipeline.

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
