### PR TITLE
feat: [SRTP-1821] Increase consumer pods in prod

### DIFF
--- a/helm/prod/top/rtp-consumer/values.yaml
+++ b/helm/prod/top/rtp-consumer/values.yaml
@@ -18,16 +18,16 @@ microservice-chart:
       memory: "1Gi"
 
   autoscaling:
-    enable: false
-  #    minReplica: 1
-  #    maxReplica: 3
-  #    pollingInterval: 30 # seconds
-  #    cooldownPeriod: 300 # seconds
-  #    triggers:
-  #      - type: cpu
-  #        metadata:
-  #          type: Utilization
-  #          value: "60"
+    enable: true
+    minReplica: 4
+    maxReplica: 6
+    pollingInterval: 30 # seconds
+    cooldownPeriod: 300 # seconds
+    triggers:
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "60"
 
   envConfig:
     PROCESS_GPD_MESSAGE_BASE_URL: "https://api-rtp.cstar.pagopa.it/rtp/rtps/"


### PR DESCRIPTION
#### List of Changes

- Enabled autoscaling for the `rtp-consumer` service in production ([helm/prod/top/rtp-consumer/values.yaml](helm/prod/top/rtp-consumer/values.yaml)).
- Set `minReplica: 4` and `maxReplica: 6` with CPU-based scaling trigger at 60% utilization.
- Replaced the previously disabled and commented-out autoscaling block with a fully active configuration.

#### Motivation and Context

The `rtp-consumer` service in production was running with autoscaling disabled, relying on the default replica count. Under increased load, this caused insufficient consumer capacity and thus an increasing delay between Kafka Queue production and consumer. This change enables KEDA-based CPU autoscaling with a minimum of 4 pods to ensure baseline throughput and allow the service to scale up to 6 pods under load.

#### How Has This Been Tested?

Configuration follows the same autoscaling pattern already validated in other environments and services in this repository. The change can be verified by observing pod count and CPU metrics in the production namespace after deployment.

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
