### PR TITLE
feat: [SRTP-1828] Add CosmosDB connection string to rtp-consumer

### DIFF
--- a/helm/_global/rtp-consumer.yaml
+++ b/helm/_global/rtp-consumer.yaml
@@ -82,6 +82,7 @@ microservice-chart:
     LOG_LEVEL_MONGODB_DRIVER: "WARN"
 
   envSecret:
+    COSMOS_ACCOUNT_RTP_CONNECTION_STRING: "cosmosdb-account-rtp-primary-connection-string"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "appinsights-connection-string"
     GPD_EVENTHUB_CONNECTION_STRING: "gpd-eventhub-connection-string"
     PROCESS_MESSAGE_CLIENT_SECRET: "mil-auth-client-secret-consumer"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
This PR updates the shared Helm values for the **rtp-consumer** deployment to provide the CosmosDB connection string via Kubernetes secrets, aligning rtp-consumer with the other SRTP components that already expose `COSMOS_ACCOUNT_RTP_CONNECTION_STRING`.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- Added `COSMOS_ACCOUNT_RTP_CONNECTION_STRING` under `envSecret` for `helm/_global/rtp-consumer.yaml`.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This has been tested by deploying `rtp-consumer` with the new secret, verifying that connection to database works as iontended.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
