### PR TITLE
feat: [SRTP-1870] add env retry cosmos

### DIFF
--- a/helm/dev/top/rtp-consumer/values.yaml
+++ b/helm/dev/top/rtp-consumer/values.yaml
@@ -38,7 +38,7 @@ microservice-chart:
     GPD_EVENTHUB_NAME: "pagopa-d-itn-gps-rtp-integration-evh"
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
-    COSMOSDB_RETRY_MAX_ATTEMPTS: "3"
+    COSMOSDB_RETRY_MAX_ATTEMPTS: "1"
     COSMOSDB_RETRY_BACKOFF_MIN_DURATION: "PT1S"
     COSMOSDB_RETRY_BACKOFF_JITTER: "0.75"
     GPD_MESSAGE_PROCESSING_ENABLED: "true"

--- a/helm/dev/top/rtp-consumer/values.yaml
+++ b/helm/dev/top/rtp-consumer/values.yaml
@@ -38,6 +38,9 @@ microservice-chart:
     GPD_EVENTHUB_NAME: "pagopa-d-itn-gps-rtp-integration-evh"
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
+    COSMOSDB_RETRY_MAX_ATTEMPTS: "3"
+    COSMOSDB_RETRY_BACKOFF_MIN_DURATION: "PT1S"
+    COSMOSDB_RETRY_BACKOFF_JITTER: "0.75"
     GPD_MESSAGE_PROCESSING_ENABLED: "true"
 
   keyvault:

--- a/helm/dev/top/rtp-consumer/values.yaml
+++ b/helm/dev/top/rtp-consumer/values.yaml
@@ -38,9 +38,6 @@ microservice-chart:
     GPD_EVENTHUB_NAME: "pagopa-d-itn-gps-rtp-integration-evh"
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
-    COSMOSDB_RETRY_MAX_ATTEMPTS: "3"
-    COSMOSDB_RETRY_BACKOFF_MIN_DURATION: "PT1S"
-    COSMOSDB_RETRY_BACKOFF_JITTER: "0.75"
     GPD_MESSAGE_PROCESSING_ENABLED: "true"
 
   keyvault:

--- a/helm/prod/top/rtp-consumer/values.yaml
+++ b/helm/prod/top/rtp-consumer/values.yaml
@@ -37,6 +37,9 @@ microservice-chart:
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
     GPD_MESSAGE_PROCESSING_ENABLED: "true"
+    COSMOSDB_RETRY_MAX_ATTEMPTS: "3"
+    COSMOSDB_RETRY_BACKOFF_MIN_DURATION: "PT1S"
+    COSMOSDB_RETRY_BACKOFF_JITTER: "0.75"
 
   keyvault:
     name: "cstar-p-itn-srtp-kv"

--- a/helm/uat/top/rtp-consumer/values.yaml
+++ b/helm/uat/top/rtp-consumer/values.yaml
@@ -37,6 +37,9 @@ microservice-chart:
     GPD_EVENTHUB_TOPIC: "rtp-events"
     GPD_EVENTHUB_CONSUMER_GROUP: "rtp-events-processor"
     GPD_MESSAGE_PROCESSING_ENABLED: "true"
+    COSMOSDB_RETRY_MAX_ATTEMPTS: "3"
+    COSMOSDB_RETRY_BACKOFF_MIN_DURATION: "PT1S"
+    COSMOSDB_RETRY_BACKOFF_JITTER: "0.75"
 
   keyvault:
     name: "cstar-u-itn-srtp-kv"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Added Cosmos DB retry configuration environment variables (`COSMOSDB_RETRY_MAX_ATTEMPTS`, `COSMOSDB_RETRY_BACKOFF_MIN_DURATION`, `COSMOSDB_RETRY_BACKOFF_JITTER`) for the `rtp-consumer` service.
- The changes are scoped to the `dev`,`uat` and `prod` environment.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change is required to configure and tune the Cosmos DB retry policies in the development environment. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I verified the deployment by checking Argo to ensure the new environment variables were correctly synchronized and updated in the application configuration.

#### Screenshots (if appropriate):
<img width="354" height="60" alt="Screenshot 2026-05-27 alle 10 25 26" src="https://github.com/user-attachments/assets/5d3b33ec-e3ec-438e-98ef-5f2311604aa4" />

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
