### PR TITLE
fix: [SRTP-1924] Hotfix release

### DIFF
--- a/helm/prod/top/rtp-sender/values.yaml
+++ b/helm/prod/top/rtp-sender/values.yaml
@@ -3,7 +3,7 @@ microservice-chart:
 
   image:
     repository: ghcr.io/pagopa/rtp-sender
-    tag: ghcr.io/pagopa/rtp-sender:v2.5.1-hotfix.1@sha256:863d9dbb82592c47e4ab9556e3649a273fab2cb4952b458e442de51091d4d7cc
+    tag: v2.5.1-hotfix.1
     pullPolicy: Always
 
   ingress:

--- a/helm/prod/top/rtp-sender/values.yaml
+++ b/helm/prod/top/rtp-sender/values.yaml
@@ -3,7 +3,7 @@ microservice-chart:
 
   image:
     repository: ghcr.io/pagopa/rtp-sender
-    tag: v2.5.1
+    tag: ghcr.io/pagopa/rtp-sender:v2.5.1-hotfix.1@sha256:863d9dbb82592c47e4ab9556e3649a273fab2cb4952b458e442de51091d4d7cc
     pullPolicy: Always
 
   ingress:


### PR DESCRIPTION
#### List of Changes

- Bumped the `image.tag` for `rtp-sender` in production from `v2.5.1` to `v2.5.1-hotfix.1` ([helm/prod/top/rtp-sender/values.yaml](helm/prod/top/rtp-sender/values.yaml)).

#### Motivation and Context

A hotfix was released on the `rtp-sender` service addressing a production issue. This change promotes the hotfix image (`v2.5.1-hotfix.1`) to the production environment by updating the tag in the Helm values.

#### How Has This Been Tested?

The hotfix image was validated prior to this promotion. The change is limited to the image tag update and does not affect any configuration or infrastructure.

#### Screenshots (if appropriate):

N/A

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
