### PR TITLE
feat: [SRTP-1963]: inject APPLICATIONINSIGHTS_CONNECTION_STRING into sidecar-epc-proxy container

### DIFF
--- a/helm/dev/top/rtp-sender-v2/values.yaml
+++ b/helm/dev/top/rtp-sender-v2/values.yaml
@@ -70,6 +70,11 @@ microservice-chart:
             secretKeyRef:
               name: rtp-sender-v2-microservice-chart
               key: client-certificate
+        - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: rtp-sender-v2-microservice-chart
+              key: appinsights-connection-string
 
       resources:
         requests:

--- a/helm/uat/top/rtp-sender-v2/values.yaml
+++ b/helm/uat/top/rtp-sender-v2/values.yaml
@@ -70,6 +70,11 @@ microservice-chart:
             secretKeyRef:
               name: rtp-sender-v2-microservice-chart
               key: client-certificate
+        - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: rtp-sender-v2-microservice-chart
+              key: appinsights-connection-string
 
       resources:
         requests:


### PR DESCRIPTION
List of Changes

  Added `APPLICATIONINSIGHTS_CONNECTION_STRING` env var to `epc-proxy-sidecar` container in `rtp-sender-v2` Helm values for **dev** and **uat** environments, bound to the existing `appinsights-connection-string` _K8s_ secret.

  Motivation and Context
  
  _K8s_ env vars are per-container — the sidecar does not inherit env from the main container. `APPLICATIONINSIGHTS_CONNECTION_STRING` was already declared in the main container's envSecret but missing from the sidecar, causing the _Azure Monitor OTel_ exporter to fail on boot.

  No new secret needed: `appinsights-connection-string` already exists in the cluster and is used by the main container.

  How Has This Been Tested?
  
  Config change only. Verified secret key name matches the one used by the main container (`appinsights-connection-string`).

  Screenshots (if appropriate):
  
  N/A

  Types of changes
  
  - [x] Bug fix (non-breaking change which fixes an issue)

  Checklist:

  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.